### PR TITLE
add postgres as new database

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -50,6 +50,29 @@ $ kubectl port-forward mcg-cluster-airflowui-0 8081:8080
 $ kubectl get airflowcluster/mcg-cluster -o yaml 
 ```
 
+#### Deploy Postgres based samples
+
+```bash
+# deploy base components first
+$ kubectl apply -f hack/sample/postgres-celery/base.yaml
+# after 30-60s deploy cluster components
+# using celery + git as DAG source
+$ kubectl apply -f hack/sample/postgres-celery/cluster.yaml
+# port forward to access the UI
+$ kubectl port-forward pc-cluster-airflowui-0 8080:8080
+# port forward to access the Flower
+$ kubectl port-forward pc-cluster-flower-0 5555:5555
+# get status of the CRs
+$ kubectl get airflowbase/pc-base -o yaml
+$ kubectl get airflowcluster/pc-cluster -o yaml
+
+# Against the same mc-base, we could deploy another cluster.
+# celery + gcs as DAG source (you need to update to point to your gcs bucket)
+$ kubectl apply -f hack/sample/mysql-celery-gcs/cluster.yaml
+$ kubectl port-forward mcg-cluster-airflowui-0 8081:8080
+$ kubectl get airflowcluster/mcg-cluster -o yaml
+```
+
 #### Running CloudSQL based samples
 CloudSQL(mysql)  needs to be setup on your project.
 A root password needs to be created for the CloudSQL.

--- a/hack/sample/cloudsql-celery/base.yaml
+++ b/hack/sample/cloudsql-celery/base.yaml
@@ -18,9 +18,10 @@ kind: AirflowBase
 metadata:
   name: cc-base
 spec:
-  sqlproxy:
-          project: kubeflow-193622
-          region: us-central1
-          instance: testsql-cluster
+  database:
+    sqlproxy:
+      project: kubeflow-193622
+      region: us-central1
+      instance: testsql-cluster
   storage:
     version: ""

--- a/hack/sample/cloudsql-k8s/base.yaml
+++ b/hack/sample/cloudsql-k8s/base.yaml
@@ -19,9 +19,10 @@ kind: AirflowBase
 metadata:
   name: ck-base
 spec:
-  sqlproxy:
-          project: kubeflow-193622
-          region: us-central1
-          instance: testsql-cluster
+  database:
+    sqlproxy:
+      project: kubeflow-193622
+      region: us-central1
+      instance: testsql-cluster
   storage:
     version: ""

--- a/hack/sample/cloudsql-k8s/cluster.yaml
+++ b/hack/sample/cloudsql-k8s/cluster.yaml
@@ -33,5 +33,6 @@ spec:
       repo: "https://github.com/apache/incubator-airflow/"
       once: true
       branch: master
+  database: SQLProxy
   airflowbase:
     name: ck-base

--- a/hack/sample/cloudsql-local/base.yaml
+++ b/hack/sample/cloudsql-local/base.yaml
@@ -19,9 +19,10 @@ kind: AirflowBase
 metadata:
   name: cl-base
 spec:
-  sqlproxy:
-          project: kubeflow-193622
-          region: us-central1
-          instance: testsql-cluster
+  database:
+    sqlproxy:
+      project: kubeflow-193622
+      region: us-central1
+      instance: testsql-cluster
   storage:
     version: ""

--- a/hack/sample/mysql-celery/base.yaml
+++ b/hack/sample/mysql-celery/base.yaml
@@ -19,7 +19,8 @@ kind: AirflowBase
 metadata:
   name: mc-base
 spec:
-  mysql:
-    operator: False
+  database:
+    mysql:
+      operator: False
   storage:
     version: ""

--- a/hack/sample/postgres-celery/base.yaml
+++ b/hack/sample/postgres-celery/base.yaml
@@ -15,26 +15,12 @@
 #
 
 apiVersion: airflow.k8s.io/v1alpha1
-kind: AirflowCluster
+kind: AirflowBase
 metadata:
-  name: cc-cluster
+  name: pc-base
 spec:
-  executor: Celery
-  redis:
-    operator: False
-  scheduler:
-    version: "1.10.0rc2"
-  ui:
-    replicas: 1
-    version: "1.10.0rc2"
-  worker:
-    replicas: 2
-    version: "1.10.0rc2"
-  dags:
-    subdir: "airflow/example_dags/"
-    git:
-      repo: "https://github.com/apache/incubator-airflow/"
-      once: true
-  database: SQLProxy
-  airflowbase:
-    name: cc-base
+  database:
+    postgres:
+      operator: False
+  storage:
+    version: ""

--- a/hack/sample/postgres-celery/cluster.yaml
+++ b/hack/sample/postgres-celery/cluster.yaml
@@ -17,7 +17,7 @@
 apiVersion: airflow.k8s.io/v1alpha1
 kind: AirflowCluster
 metadata:
-  name: cc-cluster
+  name: pc-cluster
 spec:
   executor: Celery
   redis:
@@ -30,11 +30,14 @@ spec:
   worker:
     replicas: 2
     version: "1.10.0rc2"
+  flower:
+    replicas: 1
+    version: "1.10.0rc2"
   dags:
     subdir: "airflow/example_dags/"
     git:
       repo: "https://github.com/apache/incubator-airflow/"
       once: true
-  database: SQLProxy
+  database: Postgres
   airflowbase:
-    name: cc-base
+    name: pc-base

--- a/hack/sample/postgres-k8s/cluster.yaml
+++ b/hack/sample/postgres-k8s/cluster.yaml
@@ -17,24 +17,22 @@
 apiVersion: airflow.k8s.io/v1alpha1
 kind: AirflowCluster
 metadata:
-  name: cc-cluster
+  name: pk-cluster
 spec:
-  executor: Celery
-  redis:
-    operator: False
-  scheduler:
-    version: "1.10.0rc2"
+  executor: Kubernetes
   ui:
     replicas: 1
     version: "1.10.0rc2"
+  scheduler:
+    version: "1.10.0rc2"
   worker:
-    replicas: 2
     version: "1.10.0rc2"
   dags:
     subdir: "airflow/example_dags/"
     git:
       repo: "https://github.com/apache/incubator-airflow/"
       once: true
-  database: SQLProxy
+      branch: master
+  database: Postgres
   airflowbase:
-    name: cc-base
+    name: pc-base

--- a/hack/sample/postgres-local/cluster.yaml
+++ b/hack/sample/postgres-local/cluster.yaml
@@ -17,24 +17,14 @@
 apiVersion: airflow.k8s.io/v1alpha1
 kind: AirflowCluster
 metadata:
-  name: cc-cluster
+  name: pl-cluster
 spec:
-  executor: Celery
-  redis:
-    operator: False
-  scheduler:
-    version: "1.10.0rc2"
+  executor: Local
   ui:
     replicas: 1
     version: "1.10.0rc2"
-  worker:
-    replicas: 2
+  scheduler:
     version: "1.10.0rc2"
-  dags:
-    subdir: "airflow/example_dags/"
-    git:
-      repo: "https://github.com/apache/incubator-airflow/"
-      once: true
-  database: SQLProxy
+  database: Postgres
   airflowbase:
-    name: cc-base
+    name: pc-base

--- a/pkg/apis/airflow/v1alpha1/airflowbase_types.go
+++ b/pkg/apis/airflow/v1alpha1/airflowbase_types.go
@@ -263,13 +263,13 @@ type PostgresSpec struct {
 	// Version defines the Postgres Docker image version
 	// +optional
 	Version string `json:"version"`
-	// Replicas defines the number of running MySQL instances in a cluster
+	// Replicas defines the number of running Postgres instances in a cluster
 	// +optional
 	Replicas int32 `json:"replicas,omitempty"`
-	// VolumeClaimTemplate allows a user to specify volume claim for MySQL Server files
+	// VolumeClaimTemplate allows a user to specify volume claim for Postgres Server files
 	// +optional
 	VolumeClaimTemplate *corev1.PersistentVolumeClaim `json:"volumeClaimTemplate,omitempty"`
-	// Flag when True generates MySQLOperator CustomResource to be handled by MySQL Operator
+	// Flag when True generates PostgresOperator CustomResource to be handled by Postgres Operator
 	// If False, a StatefulSet with 1 replica is created (not for production setups)
 	// +optional
 	Operator bool `json:"operator,omitempty"`

--- a/pkg/apis/airflow/v1alpha1/airflowcluster_types.go
+++ b/pkg/apis/airflow/v1alpha1/airflowcluster_types.go
@@ -35,12 +35,18 @@ const (
 	ExecutorSequential      = "Sequential"
 	ExecutorK8s             = "Kubernetes"
 	defaultExecutor         = ExecutorLocal
+	DatabaseMySQL           = "MySQL"
+	DatabasePostgres        = "Postgres"
+	DatabaseSQLProxy        = "SQLProxy"
+	defaultDatabase         = DatabaseMySQL
 	defaultBranch           = "master"
 	defaultWorkerVersion    = "1.10.0rc2"
 	defaultSchedulerVersion = "1.10.0rc2"
 )
 
 var allowedExecutors = []string{ExecutorLocal, ExecutorSequential, ExecutorCelery, ExecutorK8s}
+
+var allowedDatabases = []string{DatabaseMySQL, DatabasePostgres, DatabaseSQLProxy}
 
 // RedisSpec defines the attributes and desired state of Redis component
 type RedisSpec struct {
@@ -251,6 +257,8 @@ type AirflowClusterSpec struct {
 	// Spec for DAG source and location
 	// +optional
 	DAGs *DagSpec `json:"dags,omitempty"`
+	// Spec for Database type
+	Database string `json:"database,omitempty"`
 	// AirflowBaseRef is a reference to the AirflowBase CR
 	AirflowBaseRef *corev1.LocalObjectReference `json:"airflowbase,omitempty"`
 }
@@ -329,9 +337,15 @@ func (b *AirflowCluster) ApplyDefaults() {
 		}
 		if b.Spec.Scheduler.DBName == "" {
 			b.Spec.Scheduler.DBName = string(RandomAlphanumericString(16))
+			if b.Spec.Database == DatabasePostgres {
+				b.Spec.Scheduler.DBName = string(RandomAlphanumericStringPostgres(16))
+			}
 		}
 		if b.Spec.Scheduler.DBUser == "" {
 			b.Spec.Scheduler.DBUser = string(RandomAlphanumericString(16))
+			if b.Spec.Database == DatabasePostgres {
+				b.Spec.Scheduler.DBUser = string(RandomAlphanumericStringPostgres(16))
+			}
 		}
 	}
 	if b.Spec.UI != nil {
@@ -377,6 +391,9 @@ func (b *AirflowCluster) ApplyDefaults() {
 			}
 		}
 	}
+	if b.Spec.Database == "" {
+		b.Spec.Database = defaultDatabase
+	}
 }
 
 // Validate the AirflowCluster
@@ -420,6 +437,16 @@ func (b *AirflowCluster) Validate() error {
 		}
 	}
 
+	allowed = false
+	for _, database := range allowedDatabases {
+		if database == b.Spec.Database {
+			allowed = true
+		}
+	}
+	if !allowed {
+		errs = append(errs, field.NotSupported(spec.Child("database"), b.Spec.Database, allowedDatabases))
+	}
+
 	if b.Spec.AirflowBaseRef == nil {
 		errs = append(errs, field.Required(spec.Child("airflowbase"), "airflowbase reference missing"))
 	} else if b.Spec.AirflowBaseRef.Name == "" {
@@ -457,7 +484,7 @@ func (b *AirflowCluster) StatusDiffers(new AirflowClusterStatus) bool {
 }
 
 // NewAirflowCluster return a defaults filled AirflowCluster object
-func NewAirflowCluster(name, namespace, executor, base string, dags *DagSpec) *AirflowCluster {
+func NewAirflowCluster(name, namespace, executor, database, base string, dags *DagSpec) *AirflowCluster {
 	c := AirflowCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -475,6 +502,7 @@ func NewAirflowCluster(name, namespace, executor, base string, dags *DagSpec) *A
 		c.Spec.Flower = &FlowerSpec{}
 	}
 	c.Spec.DAGs = dags
+	c.Spec.Database = database
 	c.Spec.AirflowBaseRef = &corev1.LocalObjectReference{Name: base}
 	c.ApplyDefaults()
 	return &c

--- a/pkg/apis/airflow/v1alpha1/utils.go
+++ b/pkg/apis/airflow/v1alpha1/utils.go
@@ -36,7 +36,7 @@ const (
 	ControllerVersion = "0.1"
 
 	PasswordCharSpace         = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	PasswordCharSpacePostgres = "abcdefghijklmnopqrstuvwxyz0123456789"
+	PasswordCharSpacePostgres = "abcdefghijklmnopqrstuvwxyz0123456789" // As Postgres would lowercase database/role name
 	LifecycleManaged          = "managed"
 	LifecycleReferred         = "referred"
 
@@ -141,6 +141,7 @@ func RandomAlphanumericStringPostgres(strlen int) []byte {
 	for i := range result {
 		result[i] = PasswordCharSpacePostgres[random.Intn(len(PasswordCharSpacePostgres))]
 	}
+	// As Postgres doesn't allow database/role name begins with number
 	for strings.Contains("0123456789", string(result[0])) {
 		result[0] = PasswordCharSpacePostgres[random.Intn(len(PasswordCharSpacePostgres))]
 	}

--- a/pkg/controller/airflowbase/controller_test.go
+++ b/pkg/controller/airflowbase/controller_test.go
@@ -57,7 +57,7 @@ var _ = Describe("AirflowBase controller", func() {
 			}
 
 			// Create the instance
-			instance.Spec.MySQL = &MySQLSpec{Operator: false}
+			instance.Spec.Database = &DatabaseSpec{MySQL: &MySQLSpec{Operator: false}}
 			client = cs.AirflowV1alpha1().AirflowBases("default")
 			_, err := client.Create(&instance)
 			Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
This is really a big PR with several changes:
- add `postgres` as new database
- move `mysql`,`sqlproxy`,`postgres` under `database`
- change `e2e` test with supporting new database
- modify current samples by moving `mysql` and `sqlproxy` under `database`
- add samples of postgres
- modify quickstart

Related Issue: [Support Postgres](https://github.com/GoogleCloudPlatform/airflow-operator/issues/16)