### PR TITLE
1.11 made a backward incompatible change for crds. Fix it.

### DIFF
--- a/hack/appcrd.yaml
+++ b/hack/appcrd.yaml
@@ -122,4 +122,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
to work with newer clusters.