### PR TITLE
Fix duplicated backlash at dagfolder

### DIFF
--- a/pkg/apis/airflow/v1alpha1/airflow.go
+++ b/pkg/apis/airflow/v1alpha1/airflow.go
@@ -167,9 +167,9 @@ func (r *AirflowCluster) getAirflowEnv(saName string, base *AirflowBase) []corev
 	dagFolder := AirflowDagsBase
 	if sp.DAGs != nil {
 		if sp.DAGs.Git != nil {
-			dagFolder = AirflowDagsBase + "/" + GitSyncDestDir + "/" + sp.DAGs.DagSubdir
+			dagFolder = AirflowDagsBase + GitSyncDestDir + "/" + sp.DAGs.DagSubdir
 		} else if sp.DAGs.GCS != nil {
-			dagFolder = AirflowDagsBase + "/" + GCSSyncDestDir + "/" + sp.DAGs.DagSubdir
+			dagFolder = AirflowDagsBase + GCSSyncDestDir + "/" + sp.DAGs.DagSubdir
 		}
 	}
 	dbType := "mysql"


### PR DESCRIPTION
Fix duplicate backlash on dagFolder when concatenating AirflowDagsBase with GitSyncDestDir or GCSSyncDestDir.