### PR TITLE
Support existing Redis instance (redis/memorystore)

### DIFF
--- a/config/crds/airflow_v1alpha1_airflowcluster.yaml
+++ b/config/crds/airflow_v1alpha1_airflowcluster.yaml
@@ -105,6 +105,12 @@ spec:
                   type: string
                 operator:
                   type: boolean
+                redisHost:
+                  type: string
+                redisPassword:
+                  type: boolean
+                redisPort:
+                  type: string
                 resources:
                   type: object
                 version:

--- a/hack/sample/postgres-celery-redis/cluster.yaml
+++ b/hack/sample/postgres-celery-redis/cluster.yaml
@@ -1,0 +1,44 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: airflow.k8s.io/v1alpha1
+kind: AirflowCluster
+metadata:
+  name: pc-cluster
+spec:
+  executor: Celery
+  redis:
+    operator: False
+    redisHost: "redis"
+    redisPassword: True
+  scheduler:
+    version: "1.10.2"
+  ui:
+    replicas: 1
+    version: "1.10.2"
+  worker:
+    replicas: 2
+    version: "1.10.2"
+  flower:
+    replicas: 1
+    version: "1.10.2"
+  dags:
+    subdir: "airflow/example_dags/"
+    git:
+      repo: "https://github.com/apache/incubator-airflow/"
+      once: true
+  airflowbase:
+    name: pc-base

--- a/hack/sample/postgres-celery-redis/redis-secret.yaml
+++ b/hack/sample/postgres-celery-redis/redis-secret.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pc-cluster-redis
+type: Opaque
+data:
+  password: aGVsbG93b3JsZA==

--- a/hack/sample/postgres-celery-redis/redis.yaml
+++ b/hack/sample/postgres-celery-redis/redis.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  ports:
+    - port: 6379
+      name: redis
+  selector:
+    app: redis
+---
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis  # has to match .spec.template.metadata.labels
+  serviceName: redis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis  # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+        - name: redis
+          image: redis:4.0
+          imagePullPolicy: Always
+          args:
+          - --requirepass
+          - $(REDIS_PASSWORD)
+          env:
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: pc-cluster-redis
+          ports:
+            - containerPort: 6379
+              name: redis

--- a/hack/sample/postgres-celery-redis/redis.yaml
+++ b/hack/sample/postgres-celery-redis/redis.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Refer to issue [#69](https://github.com/GoogleCloudPlatform/airflow-operator/issues/69)
- add new fields for RedisSpec:
  - REDIS_HOST
  - REDIS_PORT
  - REDIS_PASSWORD (bool): as MemoryStore doesn't support to create new instance with password yet, and other manually created Redis instances can have passwords, if it is set to `true`, a **secret** has to be pre-created
- add example for existing Redis instance
- fix small typo for `scheduler` in `airflow.go`
